### PR TITLE
Replace pafrecord from_str with rust-csv deserialize [#8]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,20 +19,22 @@ include = [
 ]
 
 [dependencies]
+csv = "1.1"
 anyhow = "1.0"
-structopt = "0.3"
 clap = "2.33.0"
+tabled = "0.5.0"
+structopt = "0.3"
 thiserror = "1.0"
-rust-lapper = "1.0.0"
-noodles = { version = "0.20.0", features = ["fasta"] }
 crossterm = "0.23.0"
 itertools = "0.10.3"
-tabled = "0.5.0"
+rust-lapper = "1.0.0"
+serde = { version = "1.0.136", features = ["derive"] }
+noodles = { version = "0.20.0", features = ["fasta"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.1"
-predicates = "1"
 float_eq = "0.6.1"
+predicates = "1"
 
 [[bin]]
 name = "vircov"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,7 +67,7 @@ pub struct Cli {
     /// computing the bases covered by each coverage segment.
     #[structopt(short = "w", long = "width", default_value = "100")]
     pub width: u64,
-    /// Minimum reference sequence length 
+    /// Minimum reference sequence length
     ///
     /// Filters results by minimum reference sequence length
     /// which can help remove small gene alignment in large

--- a/src/covplot.rs
+++ b/src/covplot.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
-use rust_lapper::{Interval, Lapper};
-use thiserror::Error;
-
 use crossterm::execute;
 use crossterm::style::{Attribute, Color, Print, ResetColor, SetAttribute, SetForegroundColor};
+use rust_lapper::{Interval, Lapper};
 use std::io::stdout;
+use thiserror::Error;
 
 /*
 ========================


### PR DESCRIPTION
* tiny degradation in parsing speed on large test file, speedup on small test file
* in favor of safer record parsing using `rust-csv` and `serde` deserialization
* simplifies `PafRecord` custom string parsing
* full test coverage